### PR TITLE
Path fix

### DIFF
--- a/AutoSaveHighlights.ps1
+++ b/AutoSaveHighlights.ps1
@@ -143,12 +143,8 @@ function Invoke-MoveCreatedFile
 	foreach ($File_To_Move in $Files_To_Move){
 		$FileName = $File_To_Move.Name
 		$FileCreationTime = $File_To_Move.CreationTime
-
-		$year = Get-Date -Date $FileCreationTime -Format "yyyy"
-		$month = Get-Date -Date $FileCreationTime -Format "MM"
-		$day = Get-Date -Date $FileCreationTime -Format "dd"
 		
-		$FullDestinationPath = "$DestinationPath\$GameName\$year\$month\$day"
+		$FullDestinationPath = "$DestinationPath"
 		
 		if ((Test-Path -Path $FullDestinationPath) -eq $false) {
 			#Create directory if not exists
@@ -167,7 +163,7 @@ function Invoke-MoveCreatedFile
 			}
 		}
 		else {
-			Write-Host "`tFolder $GameName\$year\$month\$day doesn't exist or can't be created" -ForegroundColor Red
+			Write-Host "`tFolder $GameName doesn't exist or can't be created" -ForegroundColor Red
 			Write-Host "`tFile hasn't been moved." -ForegroundColor Red
 		}
 	}


### PR DESCRIPTION
I have no idea what you had in mind with this kind of path, but it doesn't make sense to me…

for comparison:

currently it saves the files separately in nested folders

this is what it looks like with the current code
![image](https://user-images.githubusercontent.com/37778278/203421263-94358512-569a-4d58-860f-32629d3d7b3b.png)
the path is: `\Hunt Vids\Hunt  Showdown 2022.11.20 - 21.07.53.17.DVR.mp4\2022\11\20\Hunt  Showdown 2022.11.20 - 21.07.53.17.DVR.mp4`

and this is without it
![image](https://user-images.githubusercontent.com/37778278/203421287-7b7cd36b-a8dc-4a0d-b7bc-f21204423ffb.png)
